### PR TITLE
Add genomic parsing framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,26 @@
 # GenParse
+
+GenParse is a lightweight Python framework for working with common genomic file formats.
+It includes parsers for FASTA, FASTQ, and GFF/GTF files, utilities for computing basic
+sequence statistics, simple global sequence alignment, genomic feature intersection, and
+helpers for plotting statistics.
+
+## Installation
+
+```
+pip install matplotlib
+```
+
+Clone this repository and use the modules directly or install as a package.
+
+## Example Usage
+
+```python
+from genparse import parse_fasta, gc_content, sequence_lengths, plot_length_distribution
+
+records = list(parse_fasta('example.fa'))
+lengths = sequence_lengths(r.sequence for r in records)
+print('GC%:', gc_content(records[0].sequence))
+plot_length_distribution(lengths)
+```
+

--- a/genparse/__init__.py
+++ b/genparse/__init__.py
@@ -1,0 +1,23 @@
+"""GenParse: simple genomic parsing and analysis framework."""
+
+from .fasta import FastaRecord, parse_fasta
+from .fastq import FastqRecord, parse_fastq
+from .gff import GFFFeature, parse_gff
+from .stats import gc_content, sequence_lengths
+from .alignment import AlignmentResult, needleman_wunsch
+from .intersect import Interval, intersect
+
+try:
+    from .plot import plot_length_distribution
+except Exception:  # matplotlib may not be installed
+    plot_length_distribution = None
+
+__all__ = [
+    'FastaRecord', 'parse_fasta',
+    'FastqRecord', 'parse_fastq',
+    'GFFFeature', 'parse_gff',
+    'gc_content', 'sequence_lengths',
+    'AlignmentResult', 'needleman_wunsch',
+    'Interval', 'intersect',
+    'plot_length_distribution',
+]

--- a/genparse/alignment.py
+++ b/genparse/alignment.py
@@ -1,0 +1,48 @@
+from dataclasses import dataclass
+from typing import List, Tuple
+
+@dataclass
+class AlignmentResult:
+    score: int
+    aligned_seq1: str
+    aligned_seq2: str
+
+
+def needleman_wunsch(seq1: str, seq2: str, match: int = 1, mismatch: int = -1, gap: int = -1) -> AlignmentResult:
+    """Simple global alignment using Needleman-Wunsch."""
+    n = len(seq1)
+    m = len(seq2)
+    score_matrix: List[List[int]] = [[0] * (m + 1) for _ in range(n + 1)]
+    for i in range(1, n + 1):
+        score_matrix[i][0] = i * gap
+    for j in range(1, m + 1):
+        score_matrix[0][j] = j * gap
+    for i in range(1, n + 1):
+        for j in range(1, m + 1):
+            diag = score_matrix[i - 1][j - 1] + (match if seq1[i - 1] == seq2[j - 1] else mismatch)
+            delete = score_matrix[i - 1][j] + gap
+            insert = score_matrix[i][j - 1] + gap
+            score_matrix[i][j] = max(diag, delete, insert)
+    aligned_seq1 = []
+    aligned_seq2 = []
+    i, j = n, m
+    while i > 0 or j > 0:
+        current_score = score_matrix[i][j]
+        if i > 0 and j > 0 and current_score == score_matrix[i - 1][j - 1] + (match if seq1[i - 1] == seq2[j - 1] else mismatch):
+            aligned_seq1.append(seq1[i - 1])
+            aligned_seq2.append(seq2[j - 1])
+            i -= 1
+            j -= 1
+        elif i > 0 and current_score == score_matrix[i - 1][j] + gap:
+            aligned_seq1.append(seq1[i - 1])
+            aligned_seq2.append('-')
+            i -= 1
+        else:
+            aligned_seq1.append('-')
+            aligned_seq2.append(seq2[j - 1])
+            j -= 1
+    return AlignmentResult(
+        score=score_matrix[n][m],
+        aligned_seq1=''.join(reversed(aligned_seq1)),
+        aligned_seq2=''.join(reversed(aligned_seq2)),
+    )

--- a/genparse/fasta.py
+++ b/genparse/fasta.py
@@ -1,0 +1,27 @@
+from dataclasses import dataclass
+from typing import Iterator
+
+@dataclass
+class FastaRecord:
+    header: str
+    sequence: str
+
+
+def parse_fasta(path: str) -> Iterator[FastaRecord]:
+    """Yield FastaRecord objects from a FASTA file."""
+    header = None
+    seq_lines = []
+    with open(path) as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            if line.startswith('>'):
+                if header is not None:
+                    yield FastaRecord(header, ''.join(seq_lines))
+                header = line[1:].strip()
+                seq_lines = []
+            else:
+                seq_lines.append(line)
+        if header is not None:
+            yield FastaRecord(header, ''.join(seq_lines))

--- a/genparse/fastq.py
+++ b/genparse/fastq.py
@@ -1,0 +1,24 @@
+from dataclasses import dataclass
+from typing import Iterator
+
+@dataclass
+class FastqRecord:
+    header: str
+    sequence: str
+    plus: str
+    quality: str
+
+
+def parse_fastq(path: str) -> Iterator[FastqRecord]:
+    """Yield FastqRecord objects from a FASTQ file."""
+    with open(path) as fh:
+        while True:
+            header = fh.readline().rstrip()
+            if not header:
+                break
+            seq = fh.readline().rstrip()
+            plus = fh.readline().rstrip()
+            qual = fh.readline().rstrip()
+            if not qual:
+                break
+            yield FastqRecord(header[1:], seq, plus, qual)

--- a/genparse/gff.py
+++ b/genparse/gff.py
@@ -1,0 +1,37 @@
+from dataclasses import dataclass
+from typing import Iterator, Optional
+
+@dataclass
+class GFFFeature:
+    seqid: str
+    source: str
+    type: str
+    start: int
+    end: int
+    score: Optional[str]
+    strand: str
+    phase: Optional[str]
+    attributes: str
+
+
+def parse_gff(path: str) -> Iterator[GFFFeature]:
+    """Yield GFFFeature objects from a GFF/GTF file."""
+    with open(path) as fh:
+        for line in fh:
+            line = line.strip()
+            if not line or line.startswith('#'):
+                continue
+            parts = line.split('\t')
+            if len(parts) < 9:
+                continue
+            yield GFFFeature(
+                seqid=parts[0],
+                source=parts[1],
+                type=parts[2],
+                start=int(parts[3]),
+                end=int(parts[4]),
+                score=parts[5] if parts[5] != '.' else None,
+                strand=parts[6],
+                phase=parts[7] if parts[7] != '.' else None,
+                attributes=parts[8]
+            )

--- a/genparse/intersect.py
+++ b/genparse/intersect.py
@@ -1,0 +1,22 @@
+from dataclasses import dataclass
+from typing import List, Iterator
+
+@dataclass
+class Interval:
+    chrom: str
+    start: int
+    end: int
+    metadata: dict | None = None
+
+
+def intersect(a: List[Interval], b: List[Interval]) -> Iterator[Interval]:
+    """Yield intervals representing the intersection of two interval sets."""
+    b_by_chrom = {}
+    for iv in b:
+        b_by_chrom.setdefault(iv.chrom, []).append(iv)
+    for iv in a:
+        for other in b_by_chrom.get(iv.chrom, []):
+            start = max(iv.start, other.start)
+            end = min(iv.end, other.end)
+            if start < end:
+                yield Interval(iv.chrom, start, end)

--- a/genparse/plot.py
+++ b/genparse/plot.py
@@ -1,0 +1,14 @@
+from typing import Iterable
+
+import matplotlib.pyplot as plt
+
+
+def plot_length_distribution(lengths: Iterable[int], title: str = "Sequence Lengths") -> None:
+    """Plot a histogram of sequence lengths."""
+    plt.figure(figsize=(8, 4))
+    plt.hist(list(lengths), bins=20, color='skyblue', edgecolor='black')
+    plt.title(title)
+    plt.xlabel('Length')
+    plt.ylabel('Count')
+    plt.tight_layout()
+    plt.show()

--- a/genparse/stats.py
+++ b/genparse/stats.py
@@ -1,0 +1,10 @@
+from typing import Iterable
+
+
+def gc_content(seq: str) -> float:
+    gc = sum(1 for base in seq.upper() if base in 'GC')
+    return gc / len(seq) * 100 if seq else 0.0
+
+
+def sequence_lengths(seqs: Iterable[str]) -> list[int]:
+    return [len(s) for s in seqs]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+matplotlib


### PR DESCRIPTION
## Summary
- implement python package `genparse` with parsers for FASTA/FASTQ/GFF
- add utilities for GC content calculation, length calculation and simple plotting
- provide simple Needleman-Wunsch alignment and genomic interval intersection
- update README with usage instructions and add requirements.txt
- make plotting optional in package initializer

## Testing
- `python - <<'PY'
from genparse import parse_fasta, gc_content, needleman_wunsch, Interval, intersect, sequence_lengths
open('sample.fa','w').write('>seq1\nACGTACGT\n>seq2\nACGTCG\n')
records = list(parse_fasta('sample.fa'))
print('records', records)
print('gc seq1', gc_content(records[0].sequence))
align = needleman_wunsch('ACGT','ACCT')
print('alignment score', align.score)
intervals1=[Interval('chr1',10,20),Interval('chr1',30,40)]
intervals2=[Interval('chr1',15,35)]
print('intersections', list(intersect(intervals1, intervals2)))
print('lengths', sequence_lengths(r.sequence for r in records))
PY`

------
https://chatgpt.com/codex/tasks/task_e_6865515e00ac8322bf4ddcdff02998d3