### PR TITLE
Add sequence simulation functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,14 @@ print('GC%:', gc_content(records[0].sequence))
 plot_length_distribution(lengths)
 ```
 
+## Simulating Sequences
+
+Generate random sequences of specified lengths using `simulate_sequences`:
+
+```python
+from genparse import simulate_sequences
+
+for seq in simulate_sequences([50, 75, 100]):
+    print(seq)
+```
+

--- a/genparse/__init__.py
+++ b/genparse/__init__.py
@@ -6,6 +6,7 @@ from .gff import GFFFeature, parse_gff
 from .stats import gc_content, sequence_lengths
 from .alignment import AlignmentResult, needleman_wunsch
 from .intersect import Interval, intersect
+from .simulate import simulate_sequences
 
 try:
     from .plot import plot_length_distribution
@@ -20,4 +21,5 @@ __all__ = [
     'AlignmentResult', 'needleman_wunsch',
     'Interval', 'intersect',
     'plot_length_distribution',
+    'simulate_sequences',
 ]

--- a/genparse/simulate.py
+++ b/genparse/simulate.py
@@ -1,0 +1,20 @@
+from typing import Iterable, Iterator
+import random
+
+
+def simulate_sequences(lengths: Iterable[int] | int, alphabet: str = "ACGT") -> Iterator[str]:
+    """Yield random DNA sequences for each length in ``lengths``.
+
+    Parameters
+    ----------
+    lengths:
+        Either a single integer length or an iterable of lengths specifying
+        the length of each simulated sequence.
+    alphabet:
+        String of characters to sample from when generating sequences.
+        Defaults to ``"ACGT"``.
+    """
+    if isinstance(lengths, int):
+        lengths = [lengths]
+    for length in lengths:
+        yield "".join(random.choices(alphabet, k=length))


### PR DESCRIPTION
## Summary
- implement `simulate_sequences` to generate random sequences
- export the function from the package
- document sequence simulation in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865545de0a883228826619a60e5489e